### PR TITLE
Add exists() function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,15 @@ export class CreditPricing {
 	}
 
 	/**
+	 * Checks if a given feature slug has a credit pricing definition.
+	 * @param featureSlug - feature slug to check
+	 * @returns boolean denoting if feature has a credit pricing definition
+	 */
+	public exists(featureSlug: string): boolean {
+		return Object.keys(this.credits).includes(featureSlug);
+	}
+
+	/**
 	 * Calculates the price of a credit purchase
 	 * @param featureSlug - feature slug
 	 * @param availableCredits - total of available and currently accrued credits

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -31,7 +31,7 @@ function toDollar(pennies: number): string {
 	return dollar.format(pennies / 100);
 }
 
-describe('getPricing()', function () {
+describe('Instantiation', function () {
 	it('should use passed in credit pricing', function () {
 		const custom = new CreditPricing(TEST_CREDITS);
 		expect(custom.credits).to.equal(TEST_CREDITS);
@@ -40,6 +40,16 @@ describe('getPricing()', function () {
 	it('should use default credit pricing if custom not specified', function () {
 		const standard = new CreditPricing();
 		expect(standard.credits).to.equal(CREDITS);
+	});
+});
+
+describe('exists()', function () {
+	it('should return true when feature has credit pricing definition', function () {
+		expect(pricing.exists(FEATURE_SLUG)).to.equal(true);
+	});
+
+	it('should return false when feature does not have credit pricing definition', function () {
+		expect(pricing.exists('buz:baz')).to.equal(false);
 	});
 });
 


### PR DESCRIPTION
Change-type: minor

---

Add `exists()` public function to allow consumers to more easily check if a given feature slug has credit pricing parameters defined or not.