### PR TITLE
Add versioned pricing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,16 @@
 # Balena Pricing/Savings Calculators
 
 This library provides a set of functions that can be used to calculate credit purchase costs
-and savings when compared to dynamic billing. Credit pricing parameters can be passed in during
-instantiation, useful for testing and experimentation, but pricing parameters used in production
+and savings when compared to dynamic billing. Credit pricing definitions can be passed in during
+instantiation, useful for testing and experimentation, but pricing definitions used in production
 are also defined within this package.
 
 ## Usage
 
-Use default credit pricing parameters:
 ```typescript
 import { CreditPricing } from '@balena/balena-pricing';
 
-// Format output to dollar currency
+// Format output to dollar currency.
 const dollar = Intl.NumberFormat('en-US', {
 	style: 'currency',
 	currency: 'USD',
@@ -20,20 +19,52 @@ function toDollar(pennies: number): string {
 	return dollar.format(pennies / 100);
 }
 
-// Set dynamic base price
+// Set dynamic base price.
 const dynamicPrice = 150;
 
-// Use production credit pricing parameters
+// Use production credit pricing definitions.
 let pricing = new CreditPricing();
 
-// Use custom credit pricing parameters
+// Use production credit pricing definitions.
+// Explicitly target current versions (default).
+let pricing = new CreditPricing({
+	target: 'current',
+});
+
+// Use production credit pricing definitions.
+// Target most recent versions, even those slated for future use.
+pricing = new CreditPricing({
+	target: 'latest',
+});
+
+// Use production credit pricing parameters.
+// Target version 2, will return undefined for features without a version 2.
+let pricing = new CreditPricing({
+	target: 2,
+});
+
+// Use production credit pricing parameters.
+// Target most recent versions valid up to a given date.
+let pricing = new CreditPricing({
+	target: new Date('2023-03-01T00:00:00'),
+});
+
+// Use custom credit pricing parameters.
+// Mostly useful for testing parameters against the curve,
+// should not normally be used in production.
 pricing = CreditPricing({
-	'foo:bar': {
-		basePriceCents: 150,
-		firstDiscountPriceCents: 149,
-		discountRate: 0.33,
-		discountThreshold: 12000,
-		discountThresholdPriceCents: 125,
+	credits: {
+		'foo:bar': [
+			{
+				version: 1,
+				validFrom: new Date('2023-02-01T00:00:00'),
+				basePriceCents: 150,
+				firstDiscountPriceCents: 149,
+				discountRate: 0.33,
+				discountThreshold: 12000,
+				discountThresholdPriceCents: 125,
+			},
+		],
 	},
 });
 
@@ -53,4 +84,3 @@ console.log('Discount over dynamic:', `${discount}%`);
 const totalSavings = pricing.getTotalSavings('foo:bar', 0, 1000, dynamicPrice);
 console.log('Total savings:', toDollar(totalSavings));
 ```
-

--- a/src/browser.ts
+++ b/src/browser.ts
@@ -1,4 +1,4 @@
-import { CreditPricing } from "./index";
+import { CreditPricing } from './index';
 
 // Make it accessible on the window object
 (window as any).CreditPricing = CreditPricing;


### PR DESCRIPTION
Change-type: major

---

**Additions**
- Add versioning support to credit pricing definitions
- Allow consumers to specify a version `target` option with one of the following:
  - `'current'`: Most recent valid version
  - `'latest'`: Most recent version (includes not yet valid versions)
  - `Number`: A specific version to target (e.g. `1`, `2`)
  - `Date`: A date to compare with `validFrom` entries, the most recent version valid up to this date will be used

**Breaking Changes**
- No longer exporting `CREDITS` definition. This should be referenced using `instance.credits` instead.
- Credit pricing defintions passed into the constructor are now passed in the new `options` object.
- The shape of credit pricing definitions has changed to allow for versions and validity dates.