### PR TITLE
Add tslib and update rollup config

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,9 @@
     "lint-staged": "^15.4.3",
     "mocha": "^11.1.0",
     "rimraf": "^6.0.1",
-    "ts-node": "^10.9.2",
     "rollup": "^4.34.6",
+    "ts-node": "^10.9.2",
+    "tslib": "^2.8.1",
     "typescript": "^5.7.3"
   },
   "lint-staged": {

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -8,6 +8,7 @@ export default {
 	output: {
 		dir: "browser",
 		format: "iife",
+		sourcemap: true,
 	},
 	plugins: [
 		typescript({

--- a/tsconfig.browser.json
+++ b/tsconfig.browser.json
@@ -3,7 +3,7 @@
 	"compilerOptions": {
 		"module": "node16",
 		"target": "es2017",
-		"moduleResolution": "node",
+		"moduleResolution": "node16",
 		"lib": ["dom", "es2019"],
 		"outDir": "browser/"
 	},


### PR DESCRIPTION
Change-type: patch

---

Add `tslib` devDependency to resolve this error:
```
[!] (plugin typescript) RollupError: [plugin typescript] @rollup/plugin-typescript: Could not find module 'tslib', which is required by this plugin. Is it installed?
```

See: https://github.com/balena-io-modules/balena-pricing/actions/runs/15003356892/job/43675584229?pr=27#step:10:29

Also update rollup config to resolve these warnings:
```
./src/browser.ts → browser...
(!) [plugin typescript] @rollup/plugin-typescript TS5109: Option 'moduleResolution' must be set to 'Node16' (or left unspecified) when option 'module' is set to 'Node16'.
(!) [plugin typescript] @rollup/plugin-typescript: Rollup 'sourcemap' option must be set to generate source maps.
```